### PR TITLE
CS-1 - Create rule for inline space alignments instead of tabs

### DIFF
--- a/Joomla/ruleset.xml
+++ b/Joomla/ruleset.xml
@@ -39,6 +39,17 @@
 		<exclude name="Joomla.NamingConventions.ValidFunctionName.MethodUnderscore"/>
 	</rule>
 
+	<!-- redWEB included sniffs -->
+	<rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
+	<rule ref="Generic.Commenting.Todo"/>
+	<rule ref="Generic.Commenting.Fixme"/>
+	<rule ref="Generic.Formatting.MultipleStatementAlignment"/>
+	<rule ref="Generic.NamingConventions.ConstructorName"/>
+	<rule ref="Generic.PHP.NoSilencedErrors"/>
+	<rule ref="Squiz.PHP.DisallowMultipleAssignments"/>
+	<rule ref="Squiz.PHP.Eval"/>
+	<rule ref="Squiz.PHP.NonExecutableCode"/>
+
 	<!-- Include some additional sniffs from the Generic standard -->
 	<rule ref="Generic.Arrays.DisallowShortArraySyntax" />
 	<rule ref="Generic.ControlStructures.InlineControlStructure" />
@@ -179,8 +190,6 @@
 	<rule ref="Squiz.Scope.MethodScope">
 		<message>No scope modifier specified for function "%s</message>
 	</rule>
-
-	<rule ref="Squiz.Scope.StaticThisUsage" />
 
 	<rule ref="Squiz.Strings.ConcatenationSpacing">
 		<properties>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset
+	name="redweb-phpmd-ruleset" 
+    xmlns="http://pmd.sf.net/ruleset/1.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+    xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd"
+>
+	<description>Created with the PHP Coding Standard Generator. http://edorian.github.com/php-coding-standard-generator/</description>
+	<rule ref="rulesets/design.xml/GotoStatement"/>
+	<rule ref="rulesets/naming.xml/ShortVariable"/>
+	<rule ref="rulesets/naming.xml/LongVariable"/>
+	<rule ref="rulesets/naming.xml/ShortMethodName"/>
+	<rule ref="rulesets/naming.xml/ConstantNamingConventions"/>
+	<rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
+	<rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
+	<rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
+</ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -8,7 +8,11 @@
 >
 	<description>Created with the PHP Coding Standard Generator. http://edorian.github.com/php-coding-standard-generator/</description>
 	<rule ref="rulesets/design.xml/GotoStatement"/>
-	<rule ref="rulesets/naming.xml/ShortVariable"/>
+	<rule ref="rulesets/naming.xml/ShortVariable">
+		<properties>
+			<property name="minimum" value="2"/>
+    	</properties>
+	</rule>
 	<rule ref="rulesets/naming.xml/LongVariable"/>
 	<rule ref="rulesets/naming.xml/ShortMethodName"/>
 	<rule ref="rulesets/naming.xml/ConstantNamingConventions"/>


### PR DESCRIPTION
Added new Sniffs to the PHPCS ruleset
Added a PHPMD ruleset

Equal sign "=" alignment sniff have been added
New rules added that match the Scrutinizer config

Duplicate `Squiz.Scope.StaticThisUsage` was removed (already present on line 188)