### PR TITLE
CS-5 - Hotfix for PHPCBF

### DIFF
--- a/Joomla/Sniffs/ControlStructures/WhiteSpaceBeforeSniff.php
+++ b/Joomla/Sniffs/ControlStructures/WhiteSpaceBeforeSniff.php
@@ -103,7 +103,14 @@ class Joomla_Sniffs_ControlStructures_WhiteSpaceBeforeSniff implements PHP_CodeS
 
 			if ($fix === true)
 			{
-				$phpcsFile->fixer->addNewlineBefore($stackPtr);
+				foreach ($tokens as $key => $tkn)
+				{
+					if ($tokens[$stackPtr]['line'] === $tkn['line'])
+					{
+						$phpcsFile->fixer->addNewlineBefore($key);
+						break;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This should fix some of the whitespace issues when using alternative syntax.

Example

Source:
```
<html>
// html code

<?php if ($a === $b) : ?>
    // do stuff
<?php endif; ?>
<?php if ($a > $b) : ?>
    // do other stuff
<?php endif; ?>

// html code
</html>
```

Before:
```
<html>
// html code

<?php if ($a === $b) : ?>
    // do stuff
<?php endif; ?>
<?php
if ($a > $b) : ?>
    // do other stuff <<< html here gets it's indentation messed up because of the fixer
<?php endif; ?>

// html code
</html>
```

Now:
```
<html>
// html code

<?php if ($a === $b) : ?>
    // do stuff
<?php endif; ?>

<?php if ($a > $b) : ?>
    // do other stuff <<< html should have the same indentation
<?php endif; ?>

// html code
</html>
```

This is not a 100% fix, so sometimes it might still mess with the indentation